### PR TITLE
Pattern testing

### DIFF
--- a/web/templates/miaard/c14.yaml
+++ b/web/templates/miaard/c14.yaml
@@ -1092,7 +1092,7 @@ slots:
     slot_uri: c14:000022
     multivalued: true
     range: string
-    pattern: "^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$"
+    pattern: ^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$
     required: true
     slot_group: method
   measurement_method:

--- a/web/templates/miaard/c14.yaml
+++ b/web/templates/miaard/c14.yaml
@@ -684,10 +684,11 @@ enums:
         description: Cavity Ring-Down Spectroscopy
 
 # STRUCTURED PATTERNS
-## syntax: ^{PMID}|{DOI}|{URL}|{text}$: ^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$
+## syntax: ^{PMID}|{DOI}|{URL}$: ^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$
 ## syntax: ^{termID}$: "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
 
 #settings:
+## DEPRECATED: Was used with structured_pattern, but now the above regex are implemented directly as constraints in pattern
 #  DOI: ^https:\/\/doi\.org\/10.\d{2,9}/.*$
 #  PMID: ^PMID:\d+$
 #  URL: ^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$

--- a/web/templates/miaard/c14.yaml
+++ b/web/templates/miaard/c14.yaml
@@ -683,11 +683,15 @@ enums:
       CRDS:
         description: Cavity Ring-Down Spectroscopy
 
-settings:
-  DOI: ^https:\/\/doi\.org\/10.\d{2,9}/.*$
-  PMID: ^PMID:\d+$
-  URL: ^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$
-  termID: "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
+# STRUCTURED PATTERNS
+## syntax: ^{PMID}|{DOI}|{URL}|{text}$: ^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$
+## syntax: ^{termID}$: "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
+
+#settings:
+#  DOI: ^https:\/\/doi\.org\/10.\d{2,9}/.*$
+#  PMID: ^PMID:\d+$
+#  URL: ^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$
+#  termID: "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
 
 classes:
   RadiocarbonDate:
@@ -883,10 +887,7 @@ slots:
     slot_uri: c14:000009
     multivalued: false
     range: string
-    structured_pattern:
-      syntax: ^{termID}$
-      interpolated: true
-      partial_match: false
+    pattern: "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
     required: true
     slot_group: sample
   sample_taxon_id:
@@ -902,10 +903,7 @@ slots:
     slot_uri: c14:000010
     multivalued: true
     range: string
-    structured_pattern:
-      syntax: ^{termID}$
-      interpolated: true
-      partial_match: false
+    pattern: "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
     required: true
     slot_group: sample
   sample_taxon_id_confidence:
@@ -952,10 +950,7 @@ slots:
     slot_uri: c14:000013
     multivalued: false
     range: string
-    structured_pattern:
-      syntax: ^{termID}$
-      interpolated: true
-      partial_match: false
+    pattern: "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
     required: false
     recommended: true
     slot_group: sample
@@ -1097,10 +1092,7 @@ slots:
     slot_uri: c14:000022
     multivalued: true
     range: string
-    structured_pattern:
-      syntax: ^{PMID}|{DOI}|{URL}|{text}$
-      interpolated: true
-      partial_match: false
+    pattern: "^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$"
     required: true
     slot_group: method
   measurement_method:

--- a/web/templates/miaard/schema.json
+++ b/web/templates/miaard/schema.json
@@ -1851,11 +1851,7 @@
       "range": "string",
       "required": true,
       "multivalued": false,
-      "structured_pattern": {
-        "syntax": "^{termID}$",
-        "interpolated": true,
-        "partial_match": false
-      }
+      "pattern": "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
     },
     "sample_taxon_id": {
       "name": "sample_taxon_id",
@@ -1881,11 +1877,7 @@
       "range": "string",
       "required": true,
       "multivalued": true,
-      "structured_pattern": {
-        "syntax": "^{termID}$",
-        "interpolated": true,
-        "partial_match": false
-      }
+      "pattern": "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
     },
     "sample_taxon_id_confidence": {
       "name": "sample_taxon_id_confidence",
@@ -1970,11 +1962,7 @@
       "required": false,
       "recommended": true,
       "multivalued": false,
-      "structured_pattern": {
-        "syntax": "^{termID}$",
-        "interpolated": true,
-        "partial_match": false
-      }
+      "pattern": "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
     },
     "suspected_sample_contamination": {
       "name": "suspected_sample_contamination",
@@ -2225,11 +2213,7 @@
       "range": "string",
       "required": true,
       "multivalued": true,
-      "structured_pattern": {
-        "syntax": "^{PMID}|{DOI}|{URL}|{text}$",
-        "interpolated": true,
-        "partial_match": false
-      }
+      "pattern": "^(PMID:\\d+|https:\\/\\/doi\\.org\\/10\\.\\d{2,9}/.*|https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*))$"
     },
     "measurement_method": {
       "name": "measurement_method",
@@ -2871,11 +2855,7 @@
           "range": "string",
           "required": true,
           "multivalued": false,
-          "structured_pattern": {
-            "syntax": "^{termID}$",
-            "interpolated": true,
-            "partial_match": false
-          }
+          "pattern": "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
         },
         "sample_taxon_id": {
           "name": "sample_taxon_id",
@@ -2903,11 +2883,7 @@
           "range": "string",
           "required": true,
           "multivalued": true,
-          "structured_pattern": {
-            "syntax": "^{termID}$",
-            "interpolated": true,
-            "partial_match": false
-          }
+          "pattern": "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
         },
         "sample_taxon_id_confidence": {
           "name": "sample_taxon_id_confidence",
@@ -2998,11 +2974,7 @@
           "required": false,
           "recommended": true,
           "multivalued": false,
-          "structured_pattern": {
-            "syntax": "^{termID}$",
-            "interpolated": true,
-            "partial_match": false
-          }
+          "pattern": "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
         },
         "suspected_sample_contamination": {
           "name": "suspected_sample_contamination",
@@ -3271,11 +3243,7 @@
           "range": "string",
           "required": true,
           "multivalued": true,
-          "structured_pattern": {
-            "syntax": "^{PMID}|{DOI}|{URL}|{text}$",
-            "interpolated": true,
-            "partial_match": false
-          }
+          "pattern": "^(PMID:\\d+|https:\\/\\/doi\\.org\\/10\\.\\d{2,9}/.*|https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*))$"
         },
         "measurement_method": {
           "name": "measurement_method",
@@ -3704,24 +3672,6 @@
         }
       },
       "tree_root": true
-    }
-  },
-  "settings": {
-    "DOI": {
-      "setting_key": "DOI",
-      "setting_value": "^https:\\/\\/doi\\.org\\/10.\\d{2,9}/.*$"
-    },
-    "PMID": {
-      "setting_key": "PMID",
-      "setting_value": "^PMID:\\d+$"
-    },
-    "URL": {
-      "setting_key": "URL",
-      "setting_value": "^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$"
-    },
-    "termID": {
-      "setting_key": "termID",
-      "setting_value": "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
     }
   },
   "@type": "SchemaDefinition"


### PR DESCRIPTION
Replaced `structured_pattern` with `pattern` and implemented regex constraints directly, as opposed to via `settings`.
Validating test data entries for the relevant terms locally with DH correctly flagged or accepted invalid or valid data entries.